### PR TITLE
ReMOTE SL MkI - Full support

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -6,6 +6,10 @@
 // Static configurations
 // ------------------------------
 
+// remote sl model indicator
+Config.REMOTE_SL_MKI     = "MKI"
+Config.REMOTE_SL_MKII    = "MKII"
+
 // Inc/Dec of knobs
 Config.fractionValue     = 1;
 Config.fractionMinValue  = 0.5;

--- a/Controller.js
+++ b/Controller.js
@@ -2,13 +2,25 @@
 // (c) 2014
 // Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
 
-function Controller ()
+function Controller ( remote_sl_version )
 {
     Config.init ();
 
-    var output = new MidiOutput ();
-    var input = new MkIIMidiInput ();
-    this.keysInput = new MkIIMidiInputKeys ();
+
+    if ( remote_sl_version == Config.REMOTE_SL_MKI ) {
+        var output = new MidiOutput ();
+        var input = new MkIMidiInput ();
+        this.keysInput = new MkIMidiInputKeys ();
+        this.surface = new SLMkI (output, input);
+
+    } else if ( remote_sl_version == Config.REMOTE_SL_MKII ) {
+        var output = new MidiOutput ();
+        var input = new MkIIMidiInput ();
+        this.keysInput = new MkIIMidiInputKeys ();
+        this.surface = new SLMkII (output, input);
+
+    }
+
     this.keysInput.init ();
     this.keysNoteInput = this.keysInput.createNoteInput ();
 
@@ -24,7 +36,6 @@ function Controller ()
         this.surface.setPendingMode (isSelected ? MODE_MASTER : this.surface.getPreviousMode ());
     }));
     
-    this.surface = new SLMkII (output, input);
     this.surface.setDefaultMode (MODE_TRACK);
 
     this.surface.addMode (MODE_TRACK, new TrackMode (this.model));

--- a/SLMkI.control.js
+++ b/SLMkI.control.js
@@ -6,21 +6,21 @@ loadAPI (1);
 
 load ("Config.js");
 load ("framework/ClassLoader.js");
-load ("mkii/ClassLoader.js");
+load ("mki/ClassLoader.js");
 load ("view/ClassLoader.js");
 load ("mode/ClassLoader.js");
 load ("Controller.js");
 
 // This is the only global variable, do not use it.
 var controller = null;
-var controller_type = "MKII"
+var controller_type = "MKI"
 
-host.defineController ("Novation", "SLMkII", "2.02", "D1CEE920-1E51-11E4-8C21-0800200C9A66", "Jürgen Moßgraber");
+host.defineController ("Novation", "SLMkI", "2.02", "a9041f50-0407-11e5-b939-0800200c9a66", "Jürgen Moßgraber");
 host.defineMidiPorts (2, 1);
 
-host.platformIsWindows () && host.addDeviceNameBasedDiscoveryPair (["MIDIIN2 (SL MkII)", "SL MkII"], ["MIDIOUT2 (SL MkII)"]);
-host.platformIsMac () && host.addDeviceNameBasedDiscoveryPair (["MIDIIN2 (SL MkII)", "SL MkII"], ["MIDIOUT2 (SL MkII)"]);
-host.platformIsLinux () && host.addDeviceNameBasedDiscoveryPair (["SL MkII MIDI 2", "SL MkII MIDI 1"], ["SL MkII MIDI 2"]);
+host.platformIsWindows () && host.addDeviceNameBasedDiscoveryPair (["ReMOTE SL Port 2", "ReMOTE SL Port 1"], ["ReMOTE SL Port 2"]);
+host.platformIsMac () && host.addDeviceNameBasedDiscoveryPair (["ReMOTE SL Port 2", "ReMOTE SL Port 1"], ["ReMOTE SL Port 2"]);
+host.platformIsLinux () && host.addDeviceNameBasedDiscoveryPair (["ReMOTE SL Port 2", "ReMOTE SL Port 1"], ["ReMOTE SL Port 2"]);
 
 function init ()
 {

--- a/SLMkI.control.js
+++ b/SLMkI.control.js
@@ -13,7 +13,6 @@ load ("Controller.js");
 
 // This is the only global variable, do not use it.
 var controller = null;
-var controller_type = "MKI"
 
 host.defineController ("Novation", "SLMkI", "2.02", "a9041f50-0407-11e5-b939-0800200c9a66", "Jürgen Moßgraber");
 host.defineMidiPorts (2, 1);
@@ -24,8 +23,8 @@ host.platformIsLinux () && host.addDeviceNameBasedDiscoveryPair (["ReMOTE SL Por
 
 function init ()
 {
-    controller = new Controller ();
-    println ("Initialized.");
+    controller = new Controller ( Config.REMOTE_SL_MKI );
+    println ("Initialized " + Config.REMOTE_SL_MKI + ".");
 }
 
 function exit ()

--- a/SLMkII.control.js
+++ b/SLMkII.control.js
@@ -25,7 +25,7 @@ host.platformIsLinux () && host.addDeviceNameBasedDiscoveryPair (["SL MkII MIDI 
 function init ()
 {
     controller = new Controller ( Config.REMOTE_SL_MKII );
-    println ("Initialized " + Config.REMOTE_SL_MKII + ".");
+    println ("Initialized ReMOTE SL " + Config.REMOTE_SL_MKII + ".");
 }
 
 function exit ()

--- a/SLMkII.control.js
+++ b/SLMkII.control.js
@@ -4,6 +4,7 @@
 
 loadAPI (1);
 
+
 load ("Config.js");
 load ("framework/ClassLoader.js");
 load ("mkii/ClassLoader.js");
@@ -13,7 +14,6 @@ load ("Controller.js");
 
 // This is the only global variable, do not use it.
 var controller = null;
-var controller_type = "MKII"
 
 host.defineController ("Novation", "SLMkII", "2.02", "D1CEE920-1E51-11E4-8C21-0800200C9A66", "Jürgen Moßgraber");
 host.defineMidiPorts (2, 1);
@@ -24,8 +24,8 @@ host.platformIsLinux () && host.addDeviceNameBasedDiscoveryPair (["SL MkII MIDI 
 
 function init ()
 {
-    controller = new Controller ();
-    println ("Initialized.");
+    controller = new Controller ( Config.REMOTE_SL_MKII );
+    println ("Initialized " + Config.REMOTE_SL_MKII + ".");
 }
 
 function exit ()

--- a/mki/ClassLoader.js
+++ b/mki/ClassLoader.js
@@ -1,0 +1,8 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2014
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+load ("MkIMidiInput.js");
+load ("MkIMidiInputKeys.js");
+load ("Display.js");
+load ("SLMkI.js");

--- a/mki/Display.js
+++ b/mki/Display.js
@@ -1,0 +1,81 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2014
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+Display.RIGHT_ARROW = '>';
+
+Display.SPACES =
+[
+    '',
+    ' ',
+    '  ',
+    '   ',
+    '    ',
+    '     ',
+    '      ',
+    '       ',
+    '        ',
+    '         '
+];
+
+
+// 2 rows (0-1) with 4 blocks (0-3). Each block consists of 
+// 18 characters or 2 cells (0-8).
+function Display (output)
+{
+    AbstractDisplay.call (this, output, 4 /* No of rows */, 4 /* No of blocks */, 8 /* No of cells */);
+}
+Display.prototype = new AbstractDisplay ();
+
+Display.prototype.clearCell = function (row, cell)
+{
+    this.cells[row * this.noOfCells + cell] = '         ';
+    return this;
+};
+
+Display.prototype.setBlock = function (row, block, value)
+{
+    var cell = 2 * block;
+    if (value.length > 9)
+    {
+        this.cells[row * 8 + cell]     = value.substr (0, 9);
+        this.cells[row * 8 + cell + 1] = this.pad (value.substring (9), 8, ' ') + ' ';
+    }
+    else
+    {
+        this.cells[row * 8 + cell] = this.pad (value, 9, ' ');
+        this.clearCell (row, cell + 1);
+    }
+    return this;
+};
+
+Display.prototype.setCell = function (row, cell, value, format)
+{
+    this.cells[row * this.noOfCells + cell] = this.pad (this.formatStr (value, format), 8, ' ') + ' ';
+    return this;
+};
+
+Display.prototype.writeLine = function (row, text)
+{
+    var array = [];
+    for (var i = 0; i < text.length; i++)
+        array[i] = text.charCodeAt(i);
+    this.output.sendSysex (SLMkII.SYSEX_HEADER + "02 01 00 " + uint7ToHex (row + 1) + "04 " + toHexStr (array) + "00 F7");
+};
+
+Display.prototype.formatStr = function (value, format)
+{
+    return value ? value.toString () : "";
+};
+
+Display.prototype.pad = function (str, length, character)
+{
+    if (typeof (str) == 'undefined' || str == null)
+        str = '';
+    var diff = length - str.length;
+    if (diff < 0)
+        return str.substr (0, length);
+    if (diff > 0)
+        return str + Display.SPACES[diff];
+    return str;
+};

--- a/mki/Display.js
+++ b/mki/Display.js
@@ -60,7 +60,7 @@ Display.prototype.writeLine = function (row, text)
     var array = [];
     for (var i = 0; i < text.length; i++)
         array[i] = text.charCodeAt(i);
-    this.output.sendSysex (SLMkII.SYSEX_HEADER + "02 01 00 " + uint7ToHex (row + 1) + "04 " + toHexStr (array) + "00 F7");
+    this.output.sendSysex (SLMkI.SYSEX_HEADER + "02 01 00 " + uint7ToHex (row + 1) + "04 " + toHexStr (array) + "00 F7");
 };
 
 Display.prototype.formatStr = function (value, format)

--- a/mki/MkIMidiInput.js
+++ b/mki/MkIMidiInput.js
@@ -2,16 +2,16 @@
 // (c) 2014
 // Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
 
-function MkIIMidiInput ()
+function MkIMidiInput ()
 {
     MidiInput.call (this);
 }
 
-MkIIMidiInput.prototype = new MidiInput ();
+MkIMidiInput.prototype = new MidiInput ();
 
-MkIIMidiInput.prototype.createNoteInput = function ()
+MkIMidiInput.prototype.createNoteInput = function ()
 {
-    var noteInput = this.port.createNoteInput ("Novation SL MkII (Automap)");
+    var noteInput = this.port.createNoteInput ("Novation SL MkI (Automap)");
     noteInput.setShouldConsumeEvents (false);
     return noteInput;
 };

--- a/mki/MkIMidiInput.js
+++ b/mki/MkIMidiInput.js
@@ -1,0 +1,17 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2014
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+function MkIIMidiInput ()
+{
+    MidiInput.call (this);
+}
+
+MkIIMidiInput.prototype = new MidiInput ();
+
+MkIIMidiInput.prototype.createNoteInput = function ()
+{
+    var noteInput = this.port.createNoteInput ("Novation SL MkII (Automap)");
+    noteInput.setShouldConsumeEvents (false);
+    return noteInput;
+};

--- a/mki/MkIMidiInputKeys.js
+++ b/mki/MkIMidiInputKeys.js
@@ -1,0 +1,28 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2014
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+function MkIIMidiInputKeys ()
+{
+    MidiInput.call (this);
+}
+
+MkIIMidiInputKeys.prototype = new MidiInput ();
+
+MkIIMidiInputKeys.prototype.init = function ()
+{
+    this.port = host.getMidiInPort (1);
+};
+
+MkIIMidiInputKeys.prototype.createNoteInput = function ()
+{
+    var noteInput = this.port.createNoteInput ("Novation SL MkII", 
+                                               "80????", 
+                                               "90????", 
+                                               "B0????",  // CCs
+                                               "D0????",  // Channel Aftertouch
+                                               "E0????"   // Pitchbend
+                                               );
+    noteInput.setShouldConsumeEvents (false);
+    return noteInput;
+};

--- a/mki/MkIMidiInputKeys.js
+++ b/mki/MkIMidiInputKeys.js
@@ -2,21 +2,21 @@
 // (c) 2014
 // Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
 
-function MkIIMidiInputKeys ()
+function MkIMidiInputKeys ()
 {
     MidiInput.call (this);
 }
 
-MkIIMidiInputKeys.prototype = new MidiInput ();
+MkIMidiInputKeys.prototype = new MidiInput ();
 
-MkIIMidiInputKeys.prototype.init = function ()
+MkIMidiInputKeys.prototype.init = function ()
 {
     this.port = host.getMidiInPort (1);
 };
 
-MkIIMidiInputKeys.prototype.createNoteInput = function ()
+MkIMidiInputKeys.prototype.createNoteInput = function ()
 {
-    var noteInput = this.port.createNoteInput ("Novation SL MkII", 
+    var noteInput = this.port.createNoteInput ("Novation SL MkI", 
                                                "80????", 
                                                "90????", 
                                                "B0????",  // CCs

--- a/mki/SLMkI.js
+++ b/mki/SLMkI.js
@@ -1,0 +1,455 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2014
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+var MKII_BUTTON_STATE_OFF = 0;
+var MKII_BUTTON_STATE_ON  = 1;
+
+var MKII_KNOB_ROW2_1      =  8;
+var MKII_KNOB_ROW2_2      =  9;
+var MKII_KNOB_ROW2_3      = 10;
+var MKII_KNOB_ROW2_4      = 11;
+var MKII_KNOB_ROW2_5      = 12;
+var MKII_KNOB_ROW2_6      = 13;
+var MKII_KNOB_ROW2_7      = 14;
+var MKII_KNOB_ROW2_8      = 15;
+var MKII_SLIDER1          = 16;
+var MKII_SLIDER2          = 17;
+var MKII_SLIDER3          = 18;
+var MKII_SLIDER4          = 19;
+var MKII_SLIDER5          = 20;
+var MKII_SLIDER6          = 21;
+var MKII_SLIDER7          = 22;
+var MKII_SLIDER8          = 23;
+var MKII_BUTTON_ROW1_1    = 24;
+var MKII_BUTTON_ROW1_2    = 25;
+var MKII_BUTTON_ROW1_3    = 26;
+var MKII_BUTTON_ROW1_4    = 27;
+var MKII_BUTTON_ROW1_5    = 28;
+var MKII_BUTTON_ROW1_6    = 29;
+var MKII_BUTTON_ROW1_7    = 30;
+var MKII_BUTTON_ROW1_8    = 31;
+var MKII_BUTTON_ROW2_1    = 32;
+var MKII_BUTTON_ROW2_2    = 33;
+var MKII_BUTTON_ROW2_3    = 34;
+var MKII_BUTTON_ROW2_4    = 35;
+var MKII_BUTTON_ROW2_5    = 36;
+var MKII_BUTTON_ROW2_6    = 37;
+var MKII_BUTTON_ROW2_7    = 38;
+var MKII_BUTTON_ROW2_8    = 39;
+var MKII_BUTTON_ROW3_1    = 40;
+var MKII_BUTTON_ROW3_2    = 41;
+var MKII_BUTTON_ROW3_3    = 42;
+var MKII_BUTTON_ROW3_4    = 43;
+var MKII_BUTTON_ROW3_5    = 44;
+var MKII_BUTTON_ROW3_6    = 45;
+var MKII_BUTTON_ROW3_7    = 46;
+var MKII_BUTTON_ROW3_8    = 47;
+var MKII_BUTTON_ROW4_1    = 48;
+var MKII_BUTTON_ROW4_2    = 49;
+var MKII_BUTTON_ROW4_3    = 50;
+var MKII_BUTTON_ROW4_4    = 51;
+var MKII_BUTTON_ROW4_5    = 52;
+var MKII_BUTTON_ROW4_6    = 53;
+var MKII_BUTTON_ROW4_7    = 54;
+var MKII_BUTTON_ROW4_8    = 55;
+var MKII_KNOB_ROW1_1      = 56;
+var MKII_KNOB_ROW1_2      = 57;
+var MKII_KNOB_ROW1_3      = 58;
+var MKII_KNOB_ROW1_4      = 59;
+var MKII_KNOB_ROW1_5      = 60;
+var MKII_KNOB_ROW1_6      = 61;
+var MKII_KNOB_ROW1_7      = 62;
+var MKII_KNOB_ROW1_8      = 63;
+var MKII_TOUCHPAD_X       = 68;     // This is also the crossfader on the Zero
+var MKII_TOUCHPAD_Y       = 69;
+var MKII_BUTTON_REWIND    = 72;
+var MKII_BUTTON_FORWARD   = 73;
+var MKII_BUTTON_STOP      = 74;
+var MKII_BUTTON_PLAY      = 75;
+var MKII_BUTTON_RECORD    = 76;
+var MKII_BUTTON_LOOP      = 77;
+var MKII_BUTTON_TRANSPORT = 79;
+var MKII_BUTTON_ROWSEL1   = 80;
+var MKII_BUTTON_ROWSEL2   = 81;
+var MKII_BUTTON_ROWSEL3   = 82;
+var MKII_BUTTON_ROWSEL4   = 83;
+var MKII_BUTTON_ROWSEL5   = 84;
+var MKII_BUTTON_ROWSEL6   = 85;
+var MKII_BUTTON_ROWSEL7   = 86;
+var MKII_BUTTON_ROWSEL8   = 87;
+var MKII_BUTTON_P1_UP     = 88;     // Page left on the Zero
+var MKII_BUTTON_P1_DOWN   = 89;     // Page right on the Zero
+var MKII_BUTTON_P2_UP     = 90;     // Preview + Page left on the Zero
+var MKII_BUTTON_P2_DOWN   = 91;     // Preview + Page right on the Zero
+
+
+var MK_BUTTON_TAP_TEMPO         = 94;
+
+var MK_BUTTON_TAP_TEMPO_VALUE   = 95;
+
+// the following is necessary to store the value of CC94
+// since it comprises part of the temp value
+var last_cc94_value             = 0
+
+
+var MKII_BUTTONS_ALL =
+[
+    MKII_BUTTON_ROW1_1,
+    MKII_BUTTON_ROW1_2,
+    MKII_BUTTON_ROW1_3,
+    MKII_BUTTON_ROW1_4,
+    MKII_BUTTON_ROW1_5,
+    MKII_BUTTON_ROW1_6,
+    MKII_BUTTON_ROW1_7,
+    MKII_BUTTON_ROW1_8,
+    MKII_BUTTON_ROW2_1,
+    MKII_BUTTON_ROW2_2,
+    MKII_BUTTON_ROW2_3,
+    MKII_BUTTON_ROW2_4,
+    MKII_BUTTON_ROW2_5,
+    MKII_BUTTON_ROW2_6,
+    MKII_BUTTON_ROW2_7,
+    MKII_BUTTON_ROW2_8,
+    MKII_BUTTON_ROW3_1,
+    MKII_BUTTON_ROW3_2,
+    MKII_BUTTON_ROW3_3,
+    MKII_BUTTON_ROW3_4,
+    MKII_BUTTON_ROW3_5,
+    MKII_BUTTON_ROW3_6,
+    MKII_BUTTON_ROW3_7,
+    MKII_BUTTON_ROW3_8,
+    MKII_BUTTON_ROW4_1,
+    MKII_BUTTON_ROW4_2,
+    MKII_BUTTON_ROW4_3,
+    MKII_BUTTON_ROW4_4,
+    MKII_BUTTON_ROW4_5,
+    MKII_BUTTON_ROW4_6,
+    MKII_BUTTON_ROW4_7,
+    MKII_BUTTON_ROW4_8,
+    MKII_BUTTON_REWIND,
+    MKII_BUTTON_FORWARD,
+    MKII_BUTTON_STOP,
+    MKII_BUTTON_PLAY, 
+    MKII_BUTTON_LOOP, 
+    MKII_BUTTON_RECORD,
+    //MKII_BUTTON_TRANSPORT,
+    MKII_BUTTON_ROWSEL1,
+    MKII_BUTTON_ROWSEL2,
+    MKII_BUTTON_ROWSEL3,
+    MKII_BUTTON_ROWSEL4,
+    MKII_BUTTON_ROWSEL5,
+    MKII_BUTTON_ROWSEL6,
+    MKII_BUTTON_ROWSEL7,
+    MKII_BUTTON_ROWSEL8,
+    MKII_BUTTON_P1_UP,
+    MKII_BUTTON_P1_DOWN,
+    MKII_BUTTON_P2_UP,
+    MKII_BUTTON_P2_DOWN
+];
+
+
+SLMkII.SYSEX_HEADER    = "F0 00 20 29 03 03 12 00 04 00 ";
+SLMkII.SYSEX_AUTOMAP_ON  = SLMkII.SYSEX_HEADER + "01 01 F7";
+SLMkII.SYSEX_AUTOMAP_OFF = SLMkII.SYSEX_HEADER + "01 00 F7";
+
+
+function SLMkII (output, input)
+{
+    AbstractControlSurface.call (this, output, input, MKII_BUTTONS_ALL);
+
+    var i = 0;
+    for (i = 36; i <= 43; i++)
+        this.gridNotes.push (i);
+    
+    this.buttonCCStates = initArray (-1, 128);
+    this.display = new Display (output);
+    
+    // Switch to Ableton Automap mode
+    this.output.sendSysex (SLMkII.SYSEX_AUTOMAP_ON);
+    this.turnOffAllLEDs ();
+    
+    // Disable transport mode
+    this.turnOffTransport ();
+
+    // Set LED continuous mode
+    for (i = 0; i < 8; i++)
+        this.output.sendCC (0x78 + i, 0);
+}
+SLMkII.prototype = new AbstractControlSurface ();
+
+SLMkII.prototype.setButton = function (button, state)
+{
+    if (this.buttonCCStates[button] == state)
+        return;
+    this.output.sendCC (button, state);
+    this.buttonCCStates[button] = state;
+};
+
+SLMkII.prototype.shutdown = function ()
+{
+    this.display.clear ();
+    this.turnOffAllLEDs ();
+    this.output.sendSysex (SLMkII.SYSEX_AUTOMAP_OFF);
+};
+
+SLMkII.prototype.isSelectPressed = function ()
+{
+    return false;
+};
+
+SLMkII.prototype.isShiftPressed = function ()
+{
+    return this.isTransportActive;
+};
+
+// Note: Weird to send to the DAW via SLMkII...
+SLMkII.prototype.sendMidiEvent = function (status, data1, data2)
+{
+    this.noteInput.sendRawMidiEvent (status, data1, data2);
+};
+
+//--------------------------------------
+// Handlers
+//--------------------------------------
+
+SLMkII.prototype.handleEvent = function (cc, value)
+{
+    var view = this.getActiveView ();
+    if (view == null)
+        return;
+ 
+    var event = this.isButton (cc) ? new ButtonEvent (this.buttonStates[cc]) : null;
+
+    switch (cc)
+    {
+        case MKII_BUTTON_ROW1_1:
+        case MKII_BUTTON_ROW1_2:
+        case MKII_BUTTON_ROW1_3:
+        case MKII_BUTTON_ROW1_4:
+        case MKII_BUTTON_ROW1_5:
+        case MKII_BUTTON_ROW1_6:
+        case MKII_BUTTON_ROW1_7:
+        case MKII_BUTTON_ROW1_8:
+            view.onButtonRow1 (cc - MKII_BUTTON_ROW1_1, event);
+            break;
+
+        case MKII_KNOB_ROW1_1:
+        case MKII_KNOB_ROW1_2:
+        case MKII_KNOB_ROW1_3:
+        case MKII_KNOB_ROW1_4:
+        case MKII_KNOB_ROW1_5:
+        case MKII_KNOB_ROW1_6:
+        case MKII_KNOB_ROW1_7:
+        case MKII_KNOB_ROW1_8:
+            view.onKnobRow1 (cc - MKII_KNOB_ROW1_1, value);
+            break;
+            
+        case MKII_BUTTON_ROW2_1:
+        case MKII_BUTTON_ROW2_2:
+        case MKII_BUTTON_ROW2_3:
+        case MKII_BUTTON_ROW2_4:
+        case MKII_BUTTON_ROW2_5:
+        case MKII_BUTTON_ROW2_6:
+        case MKII_BUTTON_ROW2_7:
+        case MKII_BUTTON_ROW2_8:
+            view.onButtonRow2 (cc - MKII_BUTTON_ROW2_1, event);
+            break;
+
+        case MKII_KNOB_ROW2_1:
+        case MKII_KNOB_ROW2_2:
+        case MKII_KNOB_ROW2_3:
+        case MKII_KNOB_ROW2_4:
+        case MKII_KNOB_ROW2_5:
+        case MKII_KNOB_ROW2_6:
+        case MKII_KNOB_ROW2_7:
+        case MKII_KNOB_ROW2_8:
+            view.onKnobRow2 (cc - MKII_KNOB_ROW2_1, value);
+            break;
+            
+        case MKII_SLIDER1:
+        case MKII_SLIDER2:
+        case MKII_SLIDER3:
+        case MKII_SLIDER4:
+        case MKII_SLIDER5:
+        case MKII_SLIDER6:
+        case MKII_SLIDER7:
+        case MKII_SLIDER8:
+            view.onSlider (cc - MKII_SLIDER1, value);
+            break;
+
+        case MKII_BUTTON_ROW3_1:
+        case MKII_BUTTON_ROW3_2:
+        case MKII_BUTTON_ROW3_3:
+        case MKII_BUTTON_ROW3_4:
+        case MKII_BUTTON_ROW3_5:
+        case MKII_BUTTON_ROW3_6:
+        case MKII_BUTTON_ROW3_7:
+        case MKII_BUTTON_ROW3_8:
+            view.onButtonRow3 (cc - MKII_BUTTON_ROW3_1, event);
+            break;
+
+        case MKII_BUTTON_ROW4_1:
+        case MKII_BUTTON_ROW4_2:
+        case MKII_BUTTON_ROW4_3:
+        case MKII_BUTTON_ROW4_4:
+        case MKII_BUTTON_ROW4_5:
+        case MKII_BUTTON_ROW4_6:
+        case MKII_BUTTON_ROW4_7:
+        case MKII_BUTTON_ROW4_8:
+            view.onButtonRow4 (cc - MKII_BUTTON_ROW4_1, event);
+            break;
+
+        //////////////////////////
+        // Row selections
+        //////////////////////////
+    
+        // 1st button row
+        case MKII_BUTTON_ROWSEL1:
+            if (value > 0)
+                view.onButtonRow1Select ();
+            break;
+            
+        // 1st knob row
+        case MKII_BUTTON_ROWSEL2:
+            if (value > 0)
+                view.onKnobRow1Select ();
+            break;
+            
+        // 2nd button row
+        case MKII_BUTTON_ROWSEL3:
+            if (value > 0)
+                view.onButtonRow2Select ();
+            break;
+            
+        // 2nd knob row
+        case MKII_BUTTON_ROWSEL4:
+            if (value > 0)
+                view.onKnobRow2Select ();
+            break;
+            
+        // Drum pad row
+        case MKII_BUTTON_ROWSEL5:
+            if (value > 0)
+                view.onDrumPadRowSelect ( value );
+            break;
+            
+        // Slider row
+        case MKII_BUTTON_ROWSEL6:
+            if (value > 0)
+                view.onSliderRowSelect ();
+            break;
+            
+        // 3rd button row
+        case MKII_BUTTON_ROWSEL7:
+            if (value > 0)
+                view.onButtonRow3Select ();
+            break;
+            
+        // 4th button row
+        case MKII_BUTTON_ROWSEL8:
+            if (value > 0)
+                view.onButtonRow4Select ();
+            break;
+            
+        case MKII_BUTTON_P1_UP:
+            view.onButtonP1 (true /* Up */, event);
+            break;
+            
+        case MKII_BUTTON_P1_DOWN:
+            view.onButtonP1 (false /* Down */, event);
+            break;
+            
+        case MKII_BUTTON_P2_UP:
+            view.onButtonP2 (true /* Up */, event);
+            break;
+            
+        case MKII_BUTTON_P2_DOWN:
+            view.onButtonP2 (false /* Down */, event);
+            break;
+            
+        //////////////////////////
+        // Tap Tempo
+        //////////////////////////
+
+        case MK_BUTTON_TAP_TEMPO:
+            last_cc94_value = value;
+            break;
+
+        case MK_BUTTON_TAP_TEMPO_VALUE:
+            iter = last_cc94_value;
+            tempo = 0
+            while ( iter > 0 ) {
+                tempo += 128;
+                iter--;
+            }
+            tempo += value;
+            view.onTempoMKI( tempo );
+            break;
+
+        //////////////////////////
+        // Transport
+        //////////////////////////
+
+        case MKII_BUTTON_REWIND:
+            view.onRewind (event);
+            break;
+
+        case MKII_BUTTON_FORWARD:
+            view.onForward (event);
+            break;
+
+        case MKII_BUTTON_PLAY:
+            view.onPlay (event);
+            break;
+
+        case MKII_BUTTON_STOP:
+            view.onStop (event);
+            break;
+            
+        case MKII_BUTTON_RECORD:
+            view.onRecord (event);
+            break;
+            
+        case MKII_BUTTON_LOOP:
+            view.onLoop (event);
+            break;
+            
+        //////////////////////////
+        // On-/Offline
+        //////////////////////////
+        
+        case 0x6B:
+            // Not used
+            break;
+
+        //////////////////////////
+        // Touchpad
+        //////////////////////////
+        
+        case MKII_TOUCHPAD_X:
+            view.onTouchpadX (value);
+            break;
+
+        case MKII_TOUCHPAD_Y:
+            view.onTouchpadY (value);
+            break;
+            
+        default:
+            println ("Unused Midi CC: " + cc);
+            break;
+    }
+};
+
+SLMkII.prototype.turnOffAllLEDs = function ()
+{
+    this.output.sendCC (78, 127);
+    for (var i = 0; i < 128; i++)
+        this.buttonCCStates[i] = -1;
+};
+
+SLMkII.prototype.turnOffTransport = function ()
+{
+    this.isTransportActive = false;
+    this.output.sendCC (MKII_BUTTON_TRANSPORT, 0);
+};

--- a/mki/SLMkI.js
+++ b/mki/SLMkI.js
@@ -84,16 +84,27 @@ var MKII_BUTTON_P2_UP     = 90;     // Preview + Page left on the Zero
 var MKII_BUTTON_P2_DOWN   = 91;     // Preview + Page right on the Zero
 
 
-var MK_BUTTON_TAP_TEMPO         = 94;
+var MKI_BUTTON_TAP_TEMPO         = 94;
+var MKI_BUTTON_TAP_TEMPO_VALUE   = 95;
 
-var MK_BUTTON_TAP_TEMPO_VALUE   = 95;
+
+// with the enhanced template, the drumpads emit cc 101-108
+var ENH_DPAD_1         = 120;
+var ENH_DPAD_2         = 121;
+var ENH_DPAD_3         = 122;
+var ENH_DPAD_4         = 123;
+var ENH_DPAD_5         = 124;
+var ENH_DPAD_6         = 125;
+var ENH_DPAD_7         = 126;
+var ENH_DPAD_8         = 127;
+
 
 // the following is necessary to store the value of CC94
 // since it comprises part of the temp value
-var last_cc94_value             = 0
+var last_cc94_value        = 0
 
 
-var MKII_BUTTONS_ALL =
+var MKI_BUTTONS_ALL =
 [
     MKII_BUTTON_ROW1_1,
     MKII_BUTTON_ROW1_2,
@@ -145,28 +156,39 @@ var MKII_BUTTONS_ALL =
     MKII_BUTTON_P1_UP,
     MKII_BUTTON_P1_DOWN,
     MKII_BUTTON_P2_UP,
-    MKII_BUTTON_P2_DOWN
+    MKII_BUTTON_P2_DOWN,
+    
+    ENH_DPAD_1,
+    ENH_DPAD_2,
+    ENH_DPAD_3,
+    ENH_DPAD_4,
+    ENH_DPAD_5,
+    ENH_DPAD_6,
+    ENH_DPAD_7,
+    ENH_DPAD_8
 ];
 
 
-SLMkII.SYSEX_HEADER    = "F0 00 20 29 03 03 12 00 04 00 ";
-SLMkII.SYSEX_AUTOMAP_ON  = SLMkII.SYSEX_HEADER + "01 01 F7";
-SLMkII.SYSEX_AUTOMAP_OFF = SLMkII.SYSEX_HEADER + "01 00 F7";
+SLMkI.SYSEX_HEADER    = "F0 00 20 29 03 03 12 00 04 00 ";
+SLMkI.SYSEX_AUTOMAP_ON  = SLMkI.SYSEX_HEADER + "01 01 F7";
+SLMkI.SYSEX_AUTOMAP_OFF = SLMkI.SYSEX_HEADER + "01 00 F7";
 
 
-function SLMkII (output, input)
+function SLMkI (output, input)
 {
-    AbstractControlSurface.call (this, output, input, MKII_BUTTONS_ALL);
+    AbstractControlSurface.call (this, output, input, MKI_BUTTONS_ALL);
 
     var i = 0;
     for (i = 36; i <= 43; i++)
         this.gridNotes.push (i);
     
+    this.controller_type = Config.REMOTE_SL_MKI
+
     this.buttonCCStates = initArray (-1, 128);
     this.display = new Display (output);
     
     // Switch to Ableton Automap mode
-    this.output.sendSysex (SLMkII.SYSEX_AUTOMAP_ON);
+    this.output.sendSysex (SLMkI.SYSEX_AUTOMAP_ON);
     this.turnOffAllLEDs ();
     
     // Disable transport mode
@@ -176,9 +198,9 @@ function SLMkII (output, input)
     for (i = 0; i < 8; i++)
         this.output.sendCC (0x78 + i, 0);
 }
-SLMkII.prototype = new AbstractControlSurface ();
+SLMkI.prototype = new AbstractControlSurface ();
 
-SLMkII.prototype.setButton = function (button, state)
+SLMkI.prototype.setButton = function (button, state)
 {
     if (this.buttonCCStates[button] == state)
         return;
@@ -186,25 +208,25 @@ SLMkII.prototype.setButton = function (button, state)
     this.buttonCCStates[button] = state;
 };
 
-SLMkII.prototype.shutdown = function ()
+SLMkI.prototype.shutdown = function ()
 {
     this.display.clear ();
     this.turnOffAllLEDs ();
-    this.output.sendSysex (SLMkII.SYSEX_AUTOMAP_OFF);
+    this.output.sendSysex (SLMKI.SYSEX_AUTOMAP_OFF);
 };
 
-SLMkII.prototype.isSelectPressed = function ()
+SLMkI.prototype.isSelectPressed = function ()
 {
     return false;
 };
 
-SLMkII.prototype.isShiftPressed = function ()
+SLMkI.prototype.isShiftPressed = function ()
 {
     return this.isTransportActive;
 };
 
-// Note: Weird to send to the DAW via SLMkII...
-SLMkII.prototype.sendMidiEvent = function (status, data1, data2)
+// Note: Weird to send to the DAW via SLMKII...
+SLMkI.prototype.sendMidiEvent = function (status, data1, data2)
 {
     this.noteInput.sendRawMidiEvent (status, data1, data2);
 };
@@ -213,7 +235,7 @@ SLMkII.prototype.sendMidiEvent = function (status, data1, data2)
 // Handlers
 //--------------------------------------
 
-SLMkII.prototype.handleEvent = function (cc, value)
+SLMkI.prototype.handleEvent = function (cc, value)
 {
     var view = this.getActiveView ();
     if (view == null)
@@ -441,14 +463,14 @@ SLMkII.prototype.handleEvent = function (cc, value)
     }
 };
 
-SLMkII.prototype.turnOffAllLEDs = function ()
+SLMkI.prototype.turnOffAllLEDs = function ()
 {
     this.output.sendCC (78, 127);
     for (var i = 0; i < 128; i++)
         this.buttonCCStates[i] = -1;
 };
 
-SLMkII.prototype.turnOffTransport = function ()
+SLMkI.prototype.turnOffTransport = function ()
 {
     this.isTransportActive = false;
     this.output.sendCC (MKII_BUTTON_TRANSPORT, 0);

--- a/mki/SLMkI.js
+++ b/mki/SLMkI.js
@@ -88,17 +88,6 @@ var MKI_BUTTON_TAP_TEMPO         = 94;
 var MKI_BUTTON_TAP_TEMPO_VALUE   = 95;
 
 
-// with the enhanced template, the drumpads emit cc 101-108
-var ENH_DPAD_1         = 120;
-var ENH_DPAD_2         = 121;
-var ENH_DPAD_3         = 122;
-var ENH_DPAD_4         = 123;
-var ENH_DPAD_5         = 124;
-var ENH_DPAD_6         = 125;
-var ENH_DPAD_7         = 126;
-var ENH_DPAD_8         = 127;
-
-
 // the following is necessary to store the value of CC94
 // since it comprises part of the temp value
 var last_cc94_value        = 0
@@ -156,16 +145,7 @@ var MKI_BUTTONS_ALL =
     MKII_BUTTON_P1_UP,
     MKII_BUTTON_P1_DOWN,
     MKII_BUTTON_P2_UP,
-    MKII_BUTTON_P2_DOWN,
-    
-    ENH_DPAD_1,
-    ENH_DPAD_2,
-    ENH_DPAD_3,
-    ENH_DPAD_4,
-    ENH_DPAD_5,
-    ENH_DPAD_6,
-    ENH_DPAD_7,
-    ENH_DPAD_8
+    MKII_BUTTON_P2_DOWN
 ];
 
 
@@ -212,7 +192,7 @@ SLMkI.prototype.shutdown = function ()
 {
     this.display.clear ();
     this.turnOffAllLEDs ();
-    this.output.sendSysex (SLMKI.SYSEX_AUTOMAP_OFF);
+    this.output.sendSysex (SLMkI.SYSEX_AUTOMAP_OFF);
 };
 
 SLMkI.prototype.isSelectPressed = function ()
@@ -237,6 +217,7 @@ SLMkI.prototype.sendMidiEvent = function (status, data1, data2)
 
 SLMkI.prototype.handleEvent = function (cc, value)
 {
+
     var view = this.getActiveView ();
     if (view == null)
         return;
@@ -394,11 +375,11 @@ SLMkI.prototype.handleEvent = function (cc, value)
         // Tap Tempo
         //////////////////////////
 
-        case MK_BUTTON_TAP_TEMPO:
+        case MKI_BUTTON_TAP_TEMPO:
             last_cc94_value = value;
             break;
 
-        case MK_BUTTON_TAP_TEMPO_VALUE:
+        case MKI_BUTTON_TAP_TEMPO_VALUE:
             iter = last_cc94_value;
             tempo = 0
             while ( iter > 0 ) {
@@ -461,6 +442,7 @@ SLMkI.prototype.handleEvent = function (cc, value)
             println ("Unused Midi CC: " + cc);
             break;
     }
+
 };
 
 SLMkI.prototype.turnOffAllLEDs = function ()

--- a/mkii/SLMkII.js
+++ b/mkii/SLMkII.js
@@ -152,6 +152,8 @@ function SLMkII (output, input)
     for (i = 36; i <= 43; i++)
         this.gridNotes.push (i);
     
+    this.controller_type = Config.REMOTE_SL_MKII
+    
     this.buttonCCStates = initArray (-1, 128);
     this.display = new Display (output);
     

--- a/view/AbstractViewExtensions.js
+++ b/view/AbstractViewExtensions.js
@@ -234,9 +234,9 @@ AbstractView.prototype.onKnobRow2Select = function ()
 
 AbstractView.prototype.onDrumPadRowSelect = function ( value )
 {
-    if ( controller_type == "MKI" ) {
+    if ( this.surface.controller_type == Config.REMOTE_SL_MKI ) {
         this.surface.setPendingMode (MODE_VIEW_SELECT);
-    } else if ( controller_type == "MKII" ) {
+    } else if ( this.surface.controller_type == Config.REMOTE_SL_MKII ) {
         // Not used
     }
 
@@ -254,10 +254,10 @@ AbstractView.prototype.onButtonRow3Select = function ()
 
 AbstractView.prototype.onButtonRow4Select = function ()
 {
-    if ( controller_type == "MKI" ) {
+    if ( this.surface.controller_type == Config.REMOTE_SL_MKI ) {
         this.surface.setPendingMode (MODE_VIEW_SELECT);
 
-    } else if ( controller_type == "MKII" ) {
+    } else if ( this.surface.controller_type == Config.REMOTE_SL_MKII ) {
         this.surface.setPendingMode (MODE_VOLUME);
     }
 

--- a/view/AbstractViewExtensions.js
+++ b/view/AbstractViewExtensions.js
@@ -232,9 +232,14 @@ AbstractView.prototype.onKnobRow2Select = function ()
         tb.select (0);
 };
 
-AbstractView.prototype.onDrumPadRowSelect = function ()
+AbstractView.prototype.onDrumPadRowSelect = function ( value )
 {
-    // Not used
+    if ( controller_type == "MKI" ) {
+        this.surface.setPendingMode (MODE_VIEW_SELECT);
+    } else if ( controller_type == "MKII" ) {
+        // Not used
+    }
+
 };
 
 AbstractView.prototype.onSliderRowSelect = function ()
@@ -249,7 +254,13 @@ AbstractView.prototype.onButtonRow3Select = function ()
 
 AbstractView.prototype.onButtonRow4Select = function ()
 {
-    this.surface.setPendingMode (MODE_VOLUME);
+    if ( controller_type == "MKI" ) {
+        this.surface.setPendingMode (MODE_VIEW_SELECT);
+
+    } else if ( controller_type == "MKII" ) {
+        this.surface.setPendingMode (MODE_VOLUME);
+    }
+
 };
 
 AbstractView.prototype.onButtonP2 = function (isUp, event)

--- a/view/ControlView.js
+++ b/view/ControlView.js
@@ -104,7 +104,7 @@ ControlView.prototype.onButtonRow1 = function (index, event)
             this.model.getTransport ().toggleClick ();
             break;
             
-        // Tap Tempo
+        // Tap Tempo on MKII
         case 7:
             this.model.getTransport ().tapTempo ();
             break;
@@ -250,6 +250,12 @@ ControlView.prototype.onButtonRow4 = function (index, event)
             break;
     }
 };
+
+// dedicated Tap Tempo and Tempo Data Input Knob on MKI
+ControlView.prototype.onTempoMKI = function ( value )
+{
+    this.model.getTransport().setTempo( value );
+}
 
 ControlView.prototype.doChangeTempo = function ()
 {


### PR DESCRIPTION
Additions that add full support the ReMOTE SL MkI series. Includes support for auto-discovery, ROWSEL5 & ROWSEL8 to toggle the Control/Play mode, and support for the native Tap Tempo button and Tempo Input Data knob. 

Thanks for making this great controller script for the ReMOTE series. I really love these controllers, and happen to own an MkI 25-key model. So, it's the least I can do to add full support for the MkI :+1: 

I'm also working on another branch that includes a new template and additions to support launching clip scenes with the drum pads (since they are useless for much of anything else). I still have some changes to make there, but current progress can be found here: https://github.com/adamlwatson/SLMkII4Bitwig/tree/enhanced